### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 description = "C3 for Rust"
-homepage = "https://www.github.com/simonwarchol/rust_c3"    # project home page, if any
-repository = "https://www.github.com/simonwarchol/rust_c3" # project repository, if any
+homepage = "https://github.com/simonwarchol/rust_c3"    # project home page, if any
+repository = "https://github.com/simonwarchol/rust_c3" # project repository, if any
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96